### PR TITLE
Added PostCreate scripts to allow additional VM configuration options and updated documentation.

### DIFF
--- a/HyperDeploy.psd1
+++ b/HyperDeploy.psd1
@@ -12,7 +12,7 @@
 RootModule = 'HyperDeploy.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.2'
+ModuleVersion = '0.3.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -27,7 +27,7 @@ Author = 'Tom Austin'
 CompanyName = 'Unknown'
 
 # Copyright statement for this module
-Copyright = '(c) 2021 Tom Austin. All rights reserved.'
+Copyright = '(c) 2022 Tom Austin. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'Infrastructure as Code tool for Microsoft Hyper-V'

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Tom Austin
+Copyright (c) 2022 Tom Austin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Private/Classes.ps1
+++ b/Private/Classes.ps1
@@ -14,6 +14,10 @@ class Provisioning {
     [string[]]$Scripts
 }
 
+class PostCreate {
+    [string[]]$Scripts
+}
+
 class VM:System.ICloneable {
 
     [Object] Clone () {
@@ -33,6 +37,7 @@ class VM:System.ICloneable {
     [string]$UNCCredentialScript
     [string]$CheckpointType
     [string]$NewVMDiskSizeBytes
+    [PostCreate]$PostCreate
     [Provisioning]$Provisioning
     [HyperVServer[]]$HyperVServers
     [guid]$ReplicaGuid

--- a/Private/Initialize-VM.ps1
+++ b/Private/Initialize-VM.ps1
@@ -62,6 +62,22 @@ function Wait-ForResponsiveVM {
     return $IP
 }
 
+function PostCreate-VM {
+    Param
+    (
+        [Parameter(Mandatory)]
+        [VM]$VM,
+        [Parameter(Mandatory)]
+        [HyperVServer]$HyperVServer
+
+    )
+
+    foreach ($script in $VM.PostCreate.Scripts) {
+        Write-Verbose "Running Post Create Script $script"
+        Invoke-Command -ComputerName $HyperVServer.Name -FilePath $script -ArgumentList $VM.Name
+    }
+}
+
 function Initialize-VM {
     Param
     (
@@ -105,8 +121,7 @@ function Initialize-VM {
         }
         elseif ($script.EndsWith(".Validate.ps1")) {
 
-            Write-Verbose "Validating $VMName using $script" 
-
+            
             $InvokeParams = @{ 
                 FilePath     = $script
                 ComputerName = $ip[1]
@@ -116,8 +131,7 @@ function Initialize-VM {
                 $InvokeParams.Add("Credential", $newCred)
             }
             try {
-                invoke-command @InvokeParams -ErrorAction Stop   
-                Write-Verbose "Validation script $script passed"
+                invoke-command @InvokeParams -ErrorAction Stop      
             }
             catch {
                 write-host "Validation script failed"
@@ -165,5 +179,7 @@ function Initialize-VM {
         
 
 }
+
+
 
 

--- a/Public/Publish-HyperDeploy.ps1
+++ b/Public/Publish-HyperDeploy.ps1
@@ -75,14 +75,14 @@ function Publish-HyperDeploy {
 
                 $vm.HyperVServers = @()
                 $server = New-Object HyperVServer
-                $server.Name = $env:computername
+                $server.Name = "localhost"
                 $vm.HyperVServers += $server
             }
 
             foreach ($server in $vm.HyperVServers) {
                 
                 if ($null -eq $server.Name){
-                    $server.Name = $env:computername
+                    $server.Name = "localhost"
                 }
                 
                 $servers += $server

--- a/Readme.md
+++ b/Readme.md
@@ -86,6 +86,11 @@ Example definition file:
                     "MaxReplicas" : 20
                 }
             ],
+            "PostCreate":{
+                "Scripts":[
+                    "C:\\HyperDeployScripts\\SetVLANS.ps1"
+                ]
+            },
             "Provisioning": {
                 "RebootAfterEachScript": true,
                 "RebootAfterLastScript": true,
@@ -145,6 +150,11 @@ VMS is an array of virtual machines that you want to create/destroy using HyperD
                     "MaxReplicas" : 20
                 }
             ],
+            "PostCreate":{
+                "Scripts":[
+                    "C:\\HyperDeployScripts\\SetVLANS.ps1"
+                ]
+            },
             "Provisioning": {
                 "RebootAfterEachScript": true,
                 "RebootAfterLastScript": true,
@@ -225,6 +235,23 @@ Location where you want to store the VM hard disk on the host server.
 
 #### **MaxReplicas**
 Maximum amount on replicas to assign to the host if `Replicas` are in use.
+
+### **PostCreate**
+Post create allows you to execute scripts against the created VM, the main use of these scripts is to set additional Hyper V configuration settings that HyperDeploy cannot do natively such as assign a VLAN Identifier or set VM Firmware configuration.
+```json
+"PostCreate":{
+                "Scripts":[
+                    "C:\\HyperDeployScripts\\SetVLANS.ps1"
+                ]
+            }
+```
+The name of the created VM is passed as an argument to any specified scripts. An example Post Create script may look like the following:
+
+```powershell
+param($name)
+
+Set-VMNetworkAdapterVlan -VMName $name -Access -VlanId 121
+```
 
 ### **Provisioning**
 Provisioning allows you to execute Powershell scripts against VM's created by HyperDeploy during the creation process.

--- a/Structure.json
+++ b/Structure.json
@@ -5,11 +5,15 @@
     "VMs": [
         {
             "Name": "TestVM",
-            "Replicas": 3,
             "ProcessorCount": 1,
             "MemoryStartupBytes": "1GB",
             "MemoryMaximumBytes": "4GB",
-            "CheckpointType": "Disabled"
+            "CheckpointType": "Disabled",
+            "PostCreate": {
+                "Scripts" : [
+                    "C:\\Users\\Tom\\Documents\\PostTest.ps1"
+                ]
+            }
         }
     ]
 }

--- a/Test.ps1
+++ b/Test.ps1
@@ -1,3 +1,3 @@
 Import-Module .\HyperDeploy.psm1 -Force
 
-Publish-HyperDeploy -DefinitionFile "C:\Users\TomA\source\repos\HyperDeploy\Structure2.json" -Replace  -Force -ContinueOnError -Verbose
+Publish-HyperDeploy -DefinitionFile "C:\Users\Tom\source\repos\HyperDeploy\Structure.json"  -Replace -Force


### PR DESCRIPTION
Added new PostCreate object to VM creation

### **PostCreate**
Post create allows you to execute scripts against the created VM, the main use of these scripts is to set additional Hyper V configuration settings that HyperDeploy cannot do natively such as assign a VLAN Identifier or set VM Firmware configuration.
```json
"PostCreate":{
                "Scripts":[
                    "C:\\HyperDeployScripts\\SetVLANS.ps1"
                ]
            }
```
The name of the created VM is passed as an argument to any specified scripts. An example Post Create script may look like the following:

```powershell
param($name)

Set-VMNetworkAdapterVlan -VMName $name -Access -VlanId 121
```